### PR TITLE
Remove magic

### DIFF
--- a/inference/models/mixtral.cc
+++ b/inference/models/mixtral.cc
@@ -349,7 +349,7 @@ void MIXTRAL::create_mixtral_model(FFModel &ff,
 //    Tensor topk_values_reduced = ff.reduce_sum(topk_values, {0}, true);
 //    topk_values = ff.divide(topk_values, topk_values_reduced);
 
-//    mlp_out = aggregate_inputs[5]; // TODO don't use only one expert
+    mlp_out = aggregate_inputs[5]; // TODO don't use only one expert
 
 // Everything below is needed to use aggregate // TODO try not needing the _dummy stuff
 
@@ -372,12 +372,12 @@ void MIXTRAL::create_mixtral_model(FFModel &ff,
     aggregate_inputs[2] = topk_values_DUMMY;
     aggregate_inputs[3] = gate_DUMMY;
 //
-    mlp_out = ff.aggregate(aggregate_inputs,
-                           mixtral_config.num_local_experts,
-                           0.0f,
-                           std::string("layers." + std::to_string(i) +
-                                       ".block_sparse_moe_experts_aggregate")
-                               .c_str());
+//    mlp_out = ff.aggregate(aggregate_inputs,
+//                           mixtral_config.num_local_experts,
+//                           0.0f,
+//                           std::string("layers." + std::to_string(i) +
+//                                       ".block_sparse_moe_experts_aggregate")
+//                               .c_str());
 
 //  printf("mlp_out in layer %d dims are %d %d %d %d\n",i, mlp_out->dims[0], mlp_out->dims[1], mlp_out->dims[2], mlp_out->dims[3]);
   assert(mlp_out->dims[0] == mixtral_config.hidden_size && "mlp_out dims[0] != hidden_size");

--- a/inference/models/mixtral.cc
+++ b/inference/models/mixtral.cc
@@ -45,7 +45,6 @@ void MIXTRAL::create_mixtral_model(FFModel &ff,
   }
 
   std::unordered_map<std::string, Layer *> weights_layers;
-   mixtral_config.num_local_experts = 3;
 
   Tensor input;
   {

--- a/inference/models/mixtral.cc
+++ b/inference/models/mixtral.cc
@@ -45,6 +45,7 @@ void MIXTRAL::create_mixtral_model(FFModel &ff,
   }
 
   std::unordered_map<std::string, Layer *> weights_layers;
+   mixtral_config.num_local_experts = 1;
 
   Tensor input;
   {

--- a/inference/models/mixtral.cc
+++ b/inference/models/mixtral.cc
@@ -349,7 +349,7 @@ void MIXTRAL::create_mixtral_model(FFModel &ff,
 //    Tensor topk_values_reduced = ff.reduce_sum(topk_values, {0}, true);
 //    topk_values = ff.divide(topk_values, topk_values_reduced);
 
-    mlp_out = aggregate_inputs[5]; // TODO don't use only one expert
+//    mlp_out = aggregate_inputs[5]; // TODO don't use only one expert
 
 // Everything below is needed to use aggregate // TODO try not needing the _dummy stuff
 
@@ -372,19 +372,16 @@ void MIXTRAL::create_mixtral_model(FFModel &ff,
     aggregate_inputs[2] = topk_values_DUMMY;
     aggregate_inputs[3] = gate_DUMMY;
 //
-//    mlp_out = ff.aggregate(aggregate_inputs,
-//                           mixtral_config.num_local_experts,
-//                           0.0f,
-//                           std::string("layers." + std::to_string(i) +
-//                                       ".block_sparse_moe_experts_aggregate")
-//                               .c_str());
+    mlp_out = ff.aggregate(aggregate_inputs,
+                           mixtral_config.num_local_experts,
+                           0.0f,
+                           std::string("layers." + std::to_string(i) +
+                                       ".block_sparse_moe_experts_aggregate")
+                               .c_str());
 
 //  printf("mlp_out in layer %d dims are %d %d %d %d\n",i, mlp_out->dims[0], mlp_out->dims[1], mlp_out->dims[2], mlp_out->dims[3]);
   assert(mlp_out->dims[0] == mixtral_config.hidden_size && "mlp_out dims[0] != hidden_size");
-  assert(mlp_out->dims[1] == 1 && "mlp_out dims[1] != 1");
-  assert(mlp_out->dims[2] == 128 && "mlp_out dims[2] != 128");
 //  printf("seq length is now %d\n", mlp_out->dims[2]);
-
 
  }
 

--- a/inference/models/mixtral.cc
+++ b/inference/models/mixtral.cc
@@ -45,7 +45,7 @@ void MIXTRAL::create_mixtral_model(FFModel &ff,
   }
 
   std::unordered_map<std::string, Layer *> weights_layers;
-   mixtral_config.num_local_experts = 1;
+   mixtral_config.num_local_experts = 3;
 
   Tensor input;
   {

--- a/src/ops/aggregate.cc
+++ b/src/ops/aggregate.cc
@@ -530,7 +530,7 @@ void Aggregate::forward_task(Task const *task,
 //
   AggregateMeta const *m = *((AggregateMeta **)task->local_args);
 //
-  int n = regions.size() - FIXED_ARG_CNT;
+  int n = regions.size() - FIXED_ARG_CNT - 1; // Last region is for the output
 //
 //  // get gate_pred, gate_assign, output
   AccessorRW<float, 4> const acc_gate_pred(regions[0], FID_DATA); // causes dynamic type mismatch

--- a/src/ops/aggregate.cc
+++ b/src/ops/aggregate.cc
@@ -351,13 +351,9 @@ OpMeta *Aggregate::init_task(Task const *task,
   Memory gpu_mem = get_proc_mem(Machine::get_machine(), task->target_proc);
   MemoryAllocator gpu_mem_allocator(gpu_mem);
 
-  // TODO inc_multihead_self_attention has a lot more steps here.
-  //  ... including some steps with GenericTensorAccessorR
-  //  Shoud I include?
-
   // Only needed to allocate memroy in the kernel
   AggregateMeta *m = new AggregateMeta(handle, agg, gpu_mem_allocator);
-  for (int i = 0; i < 10; i++) { // TODO 10 is a magic number
+  for (int i = 0; i < regions.size() - 1; i++) {
     m->input_type[i] = agg->inputs[i]->data_type;
   }
   m->output_type[0] = agg->outputs[0]->data_type;


### PR DESCRIPTION
02624d61706ee753c2f63740ed3b853449ee7e2c still outputs tokens with all experts. When trying a subset of experts, there's a cuda error that occurs even if we don't run aggregate()